### PR TITLE
ci: bump deprecated action versions

### DIFF
--- a/.github/workflows/check-install.yml
+++ b/.github/workflows/check-install.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v4
         with:
-          version: v3.4.0
+          version: v3.15.4
       - name: Install plugin
         run: |-
           helm plugin install https://github.com/nhomble/helm-contains

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
@@ -20,7 +20,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: github/super-linter@v3
+        uses: super-linter/super-linter@v6
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main


### PR DESCRIPTION
## Summary
Pure dependency bumps — no plugin behavior changes.

- `actions/checkout@v2` → `@v4` (v2 runs on EOL Node 12)
- `github/super-linter@v3` → `super-linter/super-linter@v6` (repo moved to its own org; v3 unmaintained)
- `azure/setup-helm@v1` → `@v4`
- Pinned helm `v3.4.0` (Nov 2020) → `v3.15.4`

## Test plan
- [ ] Linter workflow green on this PR
- [ ] Check-install workflow green on this PR

Part of a broader repo review; landing as small focused PRs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MZNc6yJGTdhRArruBjuhTN)_