### PR TITLE
docs: clarify usage, arg ordering, exit behavior

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -3,23 +3,29 @@
 image:https://github.com/nhomble/helm-contains/actions/workflows/check-install.yml/badge.svg[Check Install] image:https://github.com/nhomble/helm-contains/actions/workflows/linter.yml/badge.svg[Linter]
 
 [.lead]
-check for existence of chart
+check for existence of a chart release
 
 == Usage
+The release name is the first positional argument. The plugin prints
+`true` or `false` on stdout. It exits non-zero only on real errors
+(e.g. `helm` not on `PATH`, unreachable cluster) — a missing release
+prints `false` and exits 0.
+
 [source,bash]
 ----
-if [[ $(helm contains ${CHART_NAME}) = "true" ]]; then
+if [[ $(helm contains "${RELEASE_NAME}") = "true" ]]; then
   echo "exists"
 else
   echo "nope"
 fi
 ----
 
-And helm args are used as expected
+Standard helm flags work as expected. Pass them like you would to any
+other helm command:
 
 [source,bash]
 ----
-if [[ $(helm contains ${CHART_NAME} -n ${NOT_DEFAULT_NAMESPACE}) = "true" ]]; then
+if [[ $(helm contains -n "${NOT_DEFAULT_NAMESPACE}" "${RELEASE_NAME}") = "true" ]]; then
   echo "exists"
 fi
 ----


### PR DESCRIPTION
## Summary
README-only changes — no code.

- Call out that the release name is the first positional arg
- Document the output contract: prints `true`/`false` on stdout, exits non-zero only on real errors (missing release prints `false` and exits 0)
- Reorder the `-n` example so flags come before the positional, matching conventional helm invocation
- `CHART_NAME` → `RELEASE_NAME` (the plugin queries a release, not a chart)

## Test plan
- [ ] Render the README and confirm formatting
- [ ] No CI behavior change expected

Part of a broader repo review; landing as small focused PRs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MZNc6yJGTdhRArruBjuhTN)_