### PR TITLE
contains.sh: harden script

### DIFF
--- a/contains.sh
+++ b/contains.sh
@@ -1,9 +1,24 @@
 #!/usr/bin/env bash
 
-CHART_NAME=$1
+set -euo pipefail
 
-if ! helm status "$CHART_NAME" -n "$HELM_NAMESPACE" &> /dev/null; then
+if [[ $# -lt 1 ]]; then
+  echo "usage: helm contains [helm flags] <release-name>" >&2
+  exit 2
+fi
+
+RELEASE_NAME=$1
+
+# Capture stderr so a missing release stays quiet, but real failures
+# (helm not on PATH, unreachable cluster, bad kubeconfig) surface.
+status=0
+err=$(helm status "$RELEASE_NAME" -n "$HELM_NAMESPACE" 2>&1 >/dev/null) || status=$?
+
+if [[ $status -eq 0 ]]; then
+  echo "true"
+elif [[ $err == *"release: not found"* ]]; then
   echo "false"
 else
-  echo "true"
+  echo "$err" >&2
+  exit "$status"
 fi


### PR DESCRIPTION
## Summary
Tighten error handling in the plugin script.

- `set -euo pipefail`
- Reject calls with no positional arg (exit 2 with usage on stderr) instead of querying the literal empty string
- Capture helm stderr and only swallow it when the failure is the expected `release: not found`. Real failures (helm not on `PATH`, unreachable cluster, bad kubeconfig) now propagate with helm's exit code and error message — previously they were silently reported as the string `false`
- `CHART_NAME` → `RELEASE_NAME` (matches what `helm status` actually takes)

## Test plan
- [x] `bash -n contains.sh` — syntax clean
- [x] No-args invocation prints usage and exits 2
- [x] `PATH` without helm: surfaces `helm: command not found` and exits 127 (previously printed `false`, exit 0)
- [ ] check-install workflow stays green
- [ ] (covered separately in the flag-fix PR) end-to-end `helm contains` against a real release

Part of a broader repo review; landing as small focused PRs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MZNc6yJGTdhRArruBjuhTN)_