### PR TITLE
fix: route helm flags through helm, not the plugin script

### DIFF
--- a/.github/workflows/check-install.yml
+++ b/.github/workflows/check-install.yml
@@ -14,10 +14,34 @@ jobs:
   install:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Setup helm
         uses: azure/setup-helm@v4
         with:
           version: v3.15.4
-      - name: Install plugin
+      - name: Install plugin from checkout
         run: |-
-          helm plugin install https://github.com/nhomble/helm-contains
+          helm plugin install .
+      - name: Set up kind cluster
+        uses: helm/kind-action@v1
+      - name: Create a chart to install
+        run: |-
+          helm create testchart
+      - name: Smoke test - missing release returns false
+        run: |-
+          out=$(helm contains does-not-exist)
+          test "$out" = "false" || { echo "expected false, got: $out"; exit 1; }
+      - name: Smoke test - present release returns true
+        run: |-
+          helm install smoke ./testchart --wait
+          out=$(helm contains smoke)
+          test "$out" = "true" || { echo "expected true, got: $out"; exit 1; }
+      - name: Smoke test - -n flag is parsed by helm, not the script
+        run: |-
+          kubectl create namespace other
+          helm install smoke-ns ./testchart -n other --wait
+          out=$(helm contains -n other smoke-ns)
+          test "$out" = "true" || { echo "expected true, got: $out"; exit 1; }
+          out=$(helm contains -n other does-not-exist)
+          test "$out" = "false" || { echo "expected false, got: $out"; exit 1; }


### PR DESCRIPTION
## Summary
The headline bug from the repo review: `helm contains -n ns mychart` queries the wrong release.

With `ignoreFlags: false`, helm forwards every CLI arg verbatim to the plugin script. So `helm contains -n ns mychart` invokes `contains.sh -n ns mychart`, making `$1 == "-n"`. The wrong release name is queried, and `-n` is never seen by helm itself, so `HELM_NAMESPACE` stays at the default.

Flipping to `ignoreFlags: true` lets helm parse its own flags (still exporting `HELM_NAMESPACE` etc. into the script's environment) and only positional args reach the script — which is the assumption `$1` already encodes.

Also extends `check-install.yml` with kind-backed smoke tests that exercise this exact case:
- `helm contains <missing>` → `false`
- `helm contains <present>` → `true`
- `helm contains -n <ns> <release>` → respects the flag (regression guard)

The install step now uses `helm plugin install .` so the tests actually exercise the diff in this PR (the previous `helm plugin install <github-url>` would have pulled from `main` and bypassed the change).

## Test plan
- [ ] check-install workflow green (kind cluster spin-up, three smoke tests pass)
- [ ] The `-n other` test specifically guards against this regression

## Notes for review
- This PR is independent of the other three review PRs and can land in any order. It touches `check-install.yml` but at different lines than the CI-bump PR, so no real conflict either way.
- Action versions (`azure/setup-helm@v1`, helm `v3.4.0`) left untouched — those are the CI-bump PR's territory.

Part of a broader repo review; landing as small focused PRs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MZNc6yJGTdhRArruBjuhTN)_