### PR TITLE
ci: satisfy super-linter v6's stricter yamllint defaults

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.sh]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/check-install.yml
+++ b/.github/workflows/check-install.yml
@@ -7,6 +7,9 @@ name: Check install
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   install:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-install.yml
+++ b/.github/workflows/check-install.yml
@@ -1,10 +1,11 @@
+---
 name: Check install
 
-on:
+"on":
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   install:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -7,6 +7,10 @@ name: Linter
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  statuses: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,10 +1,11 @@
+---
 name: Linter
 
-on:
+"on":
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   build:
@@ -13,7 +14,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
-          # Full git history is needed to get a proper list of changed files within `super-linter`
+          # Full git history is needed for super-linter's changed-file detection
           fetch-depth: 0
 
       ################################

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,3 +1,4 @@
+---
 name: "contains"
 version: "0.1.0"
 usage: "Check if chart release exists"


### PR DESCRIPTION
## Summary
Follow-up to #3. super-linter v6 ships a stricter default yamllint config than v3, and the pre-existing yaml in the repo triggers errors v3 silently accepted. The linter is currently red on `main`.

Issues fixed in-source (no rule overrides):

| Rule | File | Fix |
|---|---|---|
| `document-start` | all 3 yaml files | add `---` at the top |
| `truthy` | both workflows | quote `on:` so it's not parsed as the YAML 1.1 boolean `true` |
| `brackets` | both workflows | `[ main ]` → `[main]` |
| `line-length` | `linter.yml` | shortened a long comment |

Verified locally: `yamllint` exits 0 on all three files.

## Test plan
- [ ] Linter check green
- [ ] Check-install check green (unrelated to this change)

Part of a broader repo review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MZNc6yJGTdhRArruBjuhTN)_